### PR TITLE
remove the not exist folder in the module path

### DIFF
--- a/src/tsc-wildcard-resolve.ts
+++ b/src/tsc-wildcard-resolve.ts
@@ -1,59 +1,74 @@
 import * as path from "path";
 const tsconfig = require("tsconfig");
-
 import {
-    CONFIG_FILENAME, convertToUnixPath, endsWith, escapeRegExp, getJSFiles,
-    IFileReplace, ITypescriptModule, replaceInFile, rtrim, validateTsConfig
+    CONFIG_FILENAME,
+    convertToUnixPath,
+    endsWith,
+    escapeRegExp,
+    getJSFiles,
+    IFileReplace,
+    ITypescriptModule,
+    removeNotExistFolderInPath,
+    replaceInFile,
+    rtrim,
+    validateTsConfig
 } from "./utils";
 
-function getFileReplaceTask(outDir: string, filePath: string, modules: ITypescriptModule[]) {
+function getFileReplaceTask(
+    outDir: string,
+    filePath: string,
+    modules: ITypescriptModule[]
+) {
     const replaces: IFileReplace[] = [];
 
     for (const module of modules) {
-        const moduleDir = path.resolve(outDir, module.path);
+        const moduleDir = removeNotExistFolderInPath(outDir, module.path);
         const moduleName = module.name.replace(/\/\*$/, "");
 
-        let diff = path.relative(path.resolve(moduleDir, path.dirname(filePath)), moduleDir);
+        let diff = path.relative(
+            path.resolve(moduleDir, path.dirname(filePath)),
+            moduleDir
+        );
         diff = convertToUnixPath(diff);
 
         if (!(diff.lastIndexOf(".", 0) === 0)) {
             diff = "./" + diff;
         }
 
-        const regExp1 = new RegExp(escapeRegExp(`require("${moduleName}")`), "g");
+        const regExp1 = new RegExp(
+            escapeRegExp(`require("${moduleName}")`),
+            "g"
+        );
         const replaceText1 = `require("` + diff + `")`;
 
-        const regExp2 = new RegExp(escapeRegExp(`require("${moduleName}/`), "g");
+        const regExp2 = new RegExp(
+            escapeRegExp(`require("${moduleName}/`),
+            "g"
+        );
         let replaceText2 = `require("` + diff;
 
-        const regExp3 = new RegExp(escapeRegExp(`require('${moduleName}')`), "g");
+        const regExp3 = new RegExp(
+            escapeRegExp(`require('${moduleName}')`),
+            "g"
+        );
         const replaceText3 = `require('` + diff + `')`;
 
-        const regExp4 = new RegExp(escapeRegExp(`require('${moduleName}/`), "g");
+        const regExp4 = new RegExp(
+            escapeRegExp(`require('${moduleName}/`),
+            "g"
+        );
         let replaceText4 = `require('` + diff;
 
-        const regExp5 = new RegExp(
-            escapeRegExp(`from '${moduleName}'`),
-            "g",
-        );
+        const regExp5 = new RegExp(escapeRegExp(`from '${moduleName}'`), "g");
         const replaceText5 = `from '` + diff + `'`;
 
-        const regExp6 = new RegExp(
-            escapeRegExp(`from '${moduleName}/`),
-            "g",
-        );
+        const regExp6 = new RegExp(escapeRegExp(`from '${moduleName}/`), "g");
         let replaceText6 = `from '` + diff;
 
-        const regExp7 = new RegExp(
-            escapeRegExp(`from "${moduleName}"`),
-            "g",
-        );
+        const regExp7 = new RegExp(escapeRegExp(`from "${moduleName}"`), "g");
         const replaceText7 = `from "` + diff + `"`;
 
-        const regExp8 = new RegExp(
-            escapeRegExp(`from "${moduleName}/`),
-            "g",
-        );
+        const regExp8 = new RegExp(escapeRegExp(`from "${moduleName}/`), "g");
         let replaceText8 = `from "` + diff;
 
         if (diff !== "./") {
@@ -84,7 +99,10 @@ export async function resolve(tsConfigFilePath: string) {
     const config: any = await tsconfig.readFile(tsConfigFilePath);
     validateTsConfig(config);
 
-    const outDir = path.resolve(path.dirname(tsConfigFilePath), config.compilerOptions.outDir);
+    const outDir = path.resolve(
+        path.dirname(tsConfigFilePath),
+        config.compilerOptions.outDir
+    );
 
     const jsFiles: string[] = getJSFiles(outDir);
     if (!jsFiles.length) {
@@ -95,7 +113,10 @@ export async function resolve(tsConfigFilePath: string) {
         jsFiles.map((filePath: string) => {
             const tsModules: ITypescriptModule[] = [];
             for (const moduleName of modules) {
-                const modulePath = rtrim(config.compilerOptions.paths[moduleName][0], "*"); // Remove trailing *s
+                const modulePath = rtrim(
+                    config.compilerOptions.paths[moduleName][0],
+                    "*"
+                ); // Remove trailing *s
                 tsModules.push({ name: moduleName, path: modulePath });
             }
             return getFileReplaceTask(outDir, filePath, tsModules);

--- a/src/tsc-wildcard-resolve.ts
+++ b/src/tsc-wildcard-resolve.ts
@@ -8,10 +8,7 @@ import {
     getJSFiles,
     IFileReplace,
     ITypescriptModule,
-<<<<<<< HEAD
     removeNotExistFolderInPath,
-=======
->>>>>>> ed2b42c70bbf1985b0650b10bbd1c604b11e2671
     replaceInFile,
     rtrim,
     validateTsConfig
@@ -25,14 +22,7 @@ function getFileReplaceTask(
     const replaces: IFileReplace[] = [];
 
     for (const module of modules) {
-<<<<<<< HEAD
         const moduleDir = removeNotExistFolderInPath(outDir, module.path);
-=======
-        const moduleDir = path
-            .resolve(outDir, module.path)
-            .replace("out\\dist\\src", "out\\dist\\")
-            .replace("out/dist/src/", "out/dist/");
->>>>>>> ed2b42c70bbf1985b0650b10bbd1c604b11e2671
         const moduleName = module.name.replace(/\/\*$/, "");
 
         let diff = path.relative(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as Bluebird from "bluebird";
+import { existsSync } from "fs";
 import * as path from "path";
 
 const gracefulFs = require("graceful-fs");
@@ -32,7 +33,10 @@ export function getJSFiles(dir: string, files: string[] = []) {
     return files;
 }
 
-export async function replaceInFile(filePath: string, replaces: IFileReplace[]) {
+export async function replaceInFile(
+    filePath: string,
+    replaces: IFileReplace[]
+) {
     let newSource = await fs.readFileAsync(filePath, "utf-8");
     for (const replace of replaces) {
         newSource = newSource.replace(replace.regExp, replace.text);
@@ -94,4 +98,14 @@ export function validateTsConfig(config: any) {
 
 export function endsWith(str: string, suffix: string) {
     return str.indexOf(suffix, str.length - suffix.length) !== -1;
+}
+
+export function removeNotExistFolderInPath(
+    Outpath: string,
+    modulePath: string
+) {
+    while (!existsSync(path.resolve(Outpath, modulePath))) {
+        modulePath = modulePath.replace(/[^\/]+\//, "").replace(/[^\\]\\/, "");
+    }
+    return path.resolve(Outpath, modulePath);
 }


### PR DESCRIPTION
This update create a `removeNotExistFolderInPath()` function in the utils.ts, which will remove nonexistent folder path from the module path. By doing this, the appearance of  tsc-wildcard-resolve can get red of the nonexistent  folder appear in the module path, for example `src\` folder that not appear in `out/dist/`.